### PR TITLE
Add liberal access control policy middleware

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -48,6 +48,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'core.middleware.access_control.AccessControl',
 ]
 
 ROOT_URLCONF = 'backend.urls'

--- a/core/middleware/access_control.py
+++ b/core/middleware/access_control.py
@@ -1,0 +1,11 @@
+class AccessControl:
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        response['Access-Control-Allow-Origin'] = '*'
+        response['Access-Control-Allow-Headers'] = '*'
+        response['Access-Control-Allow-Methods'] = '*'
+        return response

--- a/core/views.py
+++ b/core/views.py
@@ -33,6 +33,7 @@ def read_many(model):
         #retrieves results
         data = list(map(serializers.model_to_dict, filter_set))
         return JsonResponse({"data": data})
+
     return request_handler
 
 


### PR DESCRIPTION
All responses are now updated to allow requesters to have any origin, include any headers, and any HTTP method.