### PR TITLE
Parse date filter params

### DIFF
--- a/core/serializers.py
+++ b/core/serializers.py
@@ -11,6 +11,7 @@ def model_to_dict(obj):
         #handles datetime fields
         if type(value) == datetime.datetime:
             value = value.isoformat()
+
         #handles relational fields 
         if hasattr(value, "id"):
             value = value.id

--- a/core/views.py
+++ b/core/views.py
@@ -5,6 +5,7 @@ import json
 from django.views.decorators.csrf import csrf_exempt
 import dateutil.parser
 from django.db.models.fields import DateTimeField
+from django.utils.timezone import make_aware
 
 
 id_not_exists_err = {"message": "Requested id does not exist" }
@@ -39,7 +40,8 @@ def read_many(model):
         for key in params:
             for field in date_fields(model):
                 if key.startswith(field):
-                    params[key] = dateutil.parser.parse(params[key])
+                    naive_date = dateutil.parser.parse(params[key])
+                    params[key] = make_aware(naive_date)
 
         #applies smart filters from django
         for key in params:

--- a/core/views.py
+++ b/core/views.py
@@ -40,8 +40,13 @@ def read_many(model):
         for key in params:
             for field in date_fields(model):
                 if key.startswith(field):
-                    naive_date = dateutil.parser.parse(params[key])
-                    params[key] = make_aware(naive_date)
+                    try:
+                        naive_date = dateutil.parser.parse(params[key])
+                        params[key] = make_aware(naive_date)
+                    except:
+                        message = f"Invalid date string provided for field {key}"
+                        invalid_date_err = { "message": message }
+                        return JsonResponse({"errors": [invalid_date_err]})
 
         #applies smart filters from django
         for key in params:


### PR DESCRIPTION
Closes issue #17.

Date filter params are now converted to [datetime](https://docs.python.org/3/library/datetime.html) objects, which can be interpreted correctly by [`filter()`](https://docs.djangoproject.com/en/3.0/ref/models/querysets/#filter).

## Date params being applied
<img width="1436" alt="Screen Shot 2020-08-23 at 1 10 42 PM" src="https://user-images.githubusercontent.com/31521775/90985923-a9f27f00-e544-11ea-89c1-0c8e027fb044.png">

## Invalid Usage
<img width="1440" alt="Screen Shot 2020-08-23 at 1 26 00 PM" src="https://user-images.githubusercontent.com/31521775/90985926-ab23ac00-e544-11ea-9507-198e03ca5171.png">
